### PR TITLE
投稿、編集クエリ問題

### DIFF
--- a/app/javascript/ThanksEdit.vue
+++ b/app/javascript/ThanksEdit.vue
@@ -2,8 +2,8 @@
   <div id="app">
     <Header></Header>
     <div class="main-box">
-      <SideBar></SideBar>
-      <FormEdit></FormEdit>
+      <SideBar v-bind:sidebar-thanks="sidebarThanks"></SideBar>
+      <FormEdit v-bind:sidebar-thanks="sidebarThanks" v-on:sidebar-update="sidebarThanks = $event"></FormEdit>
     </div>
   </div>
 </template>
@@ -21,7 +21,11 @@ export default {
   },
   data: function () {
     return {
-      message: "Hello Vue!"
+      sidebarThanks: {
+        thanks: [],
+        receivers: [],
+        editUrls: []
+      }
     }
   }
 }

--- a/app/javascript/ThanksNew.vue
+++ b/app/javascript/ThanksNew.vue
@@ -2,8 +2,8 @@
   <div id="app">
     <Header></Header>
     <div class="main-box">
-      <SideBar></SideBar>
-      <FormNew></FormNew>
+      <SideBar v-bind:sidebar-thanks="sidebarThanks"></SideBar>
+      <FormNew v-bind:sidebar-thanks="sidebarThanks" v-on:sidebar-update="sidebarThanks = $event"></FormNew>
     </div>
   </div>
 </template>
@@ -21,7 +21,11 @@ export default {
   },
   data: function () {
     return {
-      message: "Hello Vue!"
+      sidebarThanks: {
+        thanks: [],
+        receivers: [],
+        editUrls: []
+      }
     }
   }
 }

--- a/app/javascript/components/FormEdit.vue
+++ b/app/javascript/components/FormEdit.vue
@@ -75,6 +75,7 @@ var editUrl = location.pathname + '.json'
 
 
 export default {
+  props: ["sidebarThanks"],
   data: function () {
     return {
       form: true,
@@ -123,6 +124,24 @@ export default {
       this.$data.thank.receiver_id = ''
       this.$data.thank.text = ''
     },
+    sidebarUpdate: function(){
+      axios
+      .get('/thanks.json')
+      .then(response => {
+        var thanks = response.data.send_thanks
+        this.sidebarThanks.thanks = thanks
+        this.sidebarThanks.receivers = response.data.receivers
+
+        var array = []
+
+        thanks.forEach(thank => {
+          var url = "/thanks/" + thank.id + "/edit"
+          array.push(url);
+        });
+        this.sidebarThanks.editUrls = array
+        this.$emit("side-update", this.sidebarThanks)
+      });
+    },
     updateThank: function(event) {
       axios
         .patch(this.updateUrl, this.thank)
@@ -137,6 +156,7 @@ export default {
 
             let e = response.data;
           }
+          this.sidebarUpdate();
           this.openModal();
         })
         .catch(error => {

--- a/app/javascript/components/FormEdit.vue
+++ b/app/javascript/components/FormEdit.vue
@@ -2,8 +2,8 @@
   <div class="form-box">
     <div class="thanks-notice">
       <p class="thanks-notice-message">
-        「確定済み」のサプライズサンクスは、総会日に一斉送信されます<br>
-        「下書き」のままでは送信されませんので、必ず期日までに<span class="emphasis">確定する</span>ボタンを押してください！
+        「公開前」のサプライズサンクスは、総会日に一斉送信されます<br>
+        「下書き」のままでは送信されませんので、必ず期日までに<span class="emphasis">更新する</span>ボタンを押してください！
       </P>
     </div>
     

--- a/app/javascript/components/FormNew.vue
+++ b/app/javascript/components/FormNew.vue
@@ -2,8 +2,8 @@
   <div class="form-box">
     <div class="thanks-notice">
       <p class="thanks-notice-message">
-        「確定済み」のサプライズサンクスは、総会日に一斉送信されます<br>
-        「下書き」のままでは送信されませんので、必ず期日までに<span class="emphasis">確定する</span>ボタンを押してください！
+        「公開前」のサプライズサンクスは、総会日に一斉送信されます<br>
+        「下書き」のままでは送信されませんので、必ず期日までに<span class="emphasis">保存する</span>ボタンを押してください！
       </P>
     </div>
     <transition enter-active-class="animated fadeInDown" leave-active-class="animated fadeOutUp">

--- a/app/javascript/components/FormNew.vue
+++ b/app/javascript/components/FormNew.vue
@@ -56,6 +56,7 @@ import axios from 'axios';
 import 'person.png'
 
 export default {
+  props: ["sidebarThanks"],
   data: function () {
     return {
       current_user: {},
@@ -120,6 +121,24 @@ export default {
       this.$data.keyword = ''
       this.$data.thank.text = ''
     },
+    sidebarUpdate: function(){
+      axios
+      .get('/thanks.json')
+      .then(response => {
+        var thanks = response.data.send_thanks
+        this.sidebarThanks.thanks = thanks
+        this.sidebarThanks.receivers = response.data.receivers
+
+        var array = []
+
+        thanks.forEach(thank => {
+          var url = "/thanks/" + thank.id + "/edit"
+          array.push(url);
+        });
+        this.sidebarThanks.editUrls = array
+        this.$emit("side-update", this.sidebarThanks)
+      });
+    },
     createThank: function(event) {
       var users = this.$data.searchUsers
 
@@ -142,6 +161,7 @@ export default {
 
             let e = response.data;
           }
+          this.sidebarUpdate();
           this.openModal();
           this.resetForm();
           this.$data.searchUsers = []
@@ -152,31 +172,7 @@ export default {
             this.errors = error.response.data.errors;
           }
         });
-    },
-    updateThank: function(event) {
-      axios
-        .post('/thanks.json', this.thank)
-        .then(response => {
-          this.errors = '';
-          if (response.status === 200){
-            if (response.data && response.data.errors) {
-            this.errors = response.data.errors;
-          }
-
-          } else {
-
-            let e = response.data;
-          }
-          this.openModal();
-          this.resetForm();
-        })
-        .catch(error => {
-          console.error(error.response.data.errors);
-          if (error.response.data && error.response.data.errors) {
-            this.errors = error.response.data.errors;
-          }
-        });
-    },
+    }
   }
 }
 </script>

--- a/app/javascript/components/SideBar.vue
+++ b/app/javascript/components/SideBar.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="side-bar">
     <transition-group enter-active-class="animated fadeInUp" leave-active-class="animated fadeOutUp" appear>
-      <li v-for="(thank, index) in thanks" :key="thank.id">
-        <a :href="editUrls[index]">
+      <li v-for="(thank, index) in sidebarThanks.thanks" :key="thank.id">
+        <a :href="sidebarThanks.editUrls[index]">
           <div class="sended-thanks-box">
             <div class="icon-box">
             <img class="logo" src="~person.png">
             </div>
             <div class="sended-message-box">
               <div class="reciver-box">
-                <p class="receiver-name">{{receivers[index]}}<span class="blank"></span>さん</p>
+                <p class="receiver-name">{{sidebarThanks.receivers[index]}}<span class="blank"></span>さん</p>
                 <p class="thanks-message">{{thank.text}}</p>
               </div>
             </div>
@@ -28,11 +28,9 @@ import axios from 'axios';
 import 'person.png'
 
 export default {
+  props: ["sidebarThanks"],
   data: function () {
     return {
-      thanks: [],
-      receivers: [],
-      editUrls: []
     }
   },
   created() {
@@ -40,31 +38,32 @@ export default {
       .get('/thanks.json')
       .then(response => {
         var thanks = response.data.send_thanks
-        this.$data.thanks = thanks
-        this.$data.receivers = response.data.receivers
+        this.sidebarThanks.thanks = thanks
+        this.sidebarThanks.receivers = response.data.receivers
+        var array = []
 
         thanks.forEach(thank => {
           var url = "/thanks/" + thank.id + "/edit"
-          var array = this.$data.editUrls
           array.push(url);
         });
+        this.sidebarThanks.editUrls = array
       });
   },
   updated() {
-    axios
-      .get('/thanks.json')
-      .then(response => {
-        var thanks = response.data.send_thanks
-        this.$data.thanks = thanks
-        this.$data.receivers = response.data.receivers
+    // axios
+    //   .get('/thanks.json')
+    //   .then(response => {
+    //     var thanks = response.data.send_thanks
+    //     this.$data.thanks = thanks
+    //     this.$data.receivers = response.data.receivers
 
-        var array = this.$data.editUrls
+    //     var array = this.$data.editUrls
 
-        thanks.forEach(thank => {
-          var url = "/thanks/" + thank.id + "/edit"
-          array.push(url);
-        });
-      });
+    //     thanks.forEach(thank => {
+    //       var url = "/thanks/" + thank.id + "/edit"
+    //       array.push(url);
+    //     });
+    //   });
   },
 }
 </script>

--- a/app/javascript/components/SideBar.vue
+++ b/app/javascript/components/SideBar.vue
@@ -48,23 +48,7 @@ export default {
         });
         this.sidebarThanks.editUrls = array
       });
-  },
-  updated() {
-    // axios
-    //   .get('/thanks.json')
-    //   .then(response => {
-    //     var thanks = response.data.send_thanks
-    //     this.$data.thanks = thanks
-    //     this.$data.receivers = response.data.receivers
-
-    //     var array = this.$data.editUrls
-
-    //     thanks.forEach(thank => {
-    //       var url = "/thanks/" + thank.id + "/edit"
-    //       array.push(url);
-    //     });
-    //   });
-  },
+  }
 }
 </script>
 


### PR DESCRIPTION
#WHY

投稿、編集画面にて表示は問題ないが裏でクエリが走り過ぎてしまう問題を解決するため。
クエリが走りすぎてしまうと将来ユーザーが多くなった際にサーバー負荷がかかりすぎることが予測されるため、修正しました。

# WHAT

ロジック
１、子コンポート（投稿、編集コンポーネント）にてサンクスが保存、更新される
２、親コンポーネントに最新のメッセージデータをイベントに乗せ伝播させる
３、親コンポーネントからサイドバーコンポーネントに対してデータを送り再描画させる

投稿例
https://gyazo.com/119d646632241f95552fddeadffefa4a