### PR TITLE
ユーザー登録機能

### DIFF
--- a/app/assets/javascripts/depart_join.js
+++ b/app/assets/javascripts/depart_join.js
@@ -1,0 +1,105 @@
+$(function() {
+
+  function buildChild1HTML() {
+    var html =
+      `<select id="depart_join_child1" name="group_id">
+            <option value>---</option>
+        </select>`
+    return html
+  }
+
+  function buildChild2HTML() {
+    var html =
+      `<select id="depart_join_child2" name="group_id">
+            <option value>---</option>
+        </select>`
+    return html
+  }
+
+  function buildChild3HTML() {
+    var html =
+      `<select id="depart_join_child3" name="group_id">
+            <option value>---</option>
+        </select>`
+    return html
+  }
+
+  function appendChild(child) {
+    return $("<option>").val($(child).attr('id')).text($(child).attr('name'))
+  }
+
+  $(document).on("change", "#depart_join_company", function(e){
+    let group_id = $(this).val();
+    $.ajax({
+      url: "/groups/get_group",
+      type: "GET",
+      data: {
+        group_id: group_id
+      },
+      dataType: 'json',
+    })
+    .done(function(groups) {
+      if (groups.length != null){
+        let html = buildChild1HTML();
+        $("#depart_child2").append(html)
+        groups.forEach(function(group) {
+          let childHTML = appendChild(group);
+          $("#depart_join_child1").append(childHTML)
+        });
+      }
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+
+  $(document).on("change", "#depart_join_child1", function(e){
+    let group_id = $(this).val();
+    $.ajax({
+      url: "/groups/get_group",
+      type: "GET",
+      data: {
+        group_id: group_id
+      },
+      dataType: 'json',
+    })
+    .done(function(groups) {
+      if (groups.length != null){
+        let html = buildChild2HTML();
+        $("#depart_child3").append(html)
+        groups.forEach(function(group) {
+          let childHTML = appendChild(group);
+          $("#depart_join_child2").append(childHTML)
+        });
+      }
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+
+  $(document).on("change", "#depart_join_child2", function(e){
+    let group_id = $(this).val();
+    $.ajax({
+      url: "/groups/get_group",
+      type: "GET",
+      data: {
+        group_id: group_id
+      },
+      dataType: 'json',
+    })
+    .done(function(groups) {
+      if (groups.length != null){
+        let html = buildChild3HTML();
+        $("#depart_child4").append(html)
+        groups.forEach(function(group) {
+          let childHTML = appendChild(group);
+          $("#depart_join_child3").append(childHTML)
+        });
+      }
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+});

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
     protected
 
     def configure_permitted_parameters
-        devise_parameter_sanitizer.permit(:account_update, keys: [:name, :status, :rank]) 
+        devise_parameter_sanitizer.permit(:account_update, keys: [:name, :status, :rank])
     end
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,0 +1,26 @@
+class CompaniesController < ApplicationController
+  def new #会社情報登録画面
+    @company = Company.new
+  end
+
+  def create #会社登録
+    @company = Company.new(company_params)
+    if @company.save
+      group = @company.groups.new(name: params[:company][:name], user_ids: [current_user.id])
+      group.group_users.first.status = "管理者"
+      group.group_users.first.request = true
+      if group.save
+        redirect_to regist_groups_path
+      else
+        render :new
+      end
+    else
+      render :new
+    end
+  end
+
+  private
+  def company_params
+    params.require(:company).permit(:name, :post_number, :address, :phone_number)
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -9,22 +9,20 @@ class GroupsController < ApplicationController
   end
 
   def create #部署登録
-    @group_1 = @parent_group.children.new(@group_params_1)
-    if @group_1.save
-      if @group_params_2[:name] != ""
-        @group_2 = @group_1.children.new(@group_params_2)
-        if @group_2.save
-          if @group_params_3[:name] != ""
-            @group_3 = @group_2.children.new(@group_params_3)
-            if @group_3.save
-            end
-          end
-        end
-      end
-      redirect_to regist_groups_path
+    case [@group_params_1[:name].present?, @group_params_2[:name].present?, @group_params_3[:name].present?]
+    when [true, false, false]
+      @group_1 = @parent_group.children.create(@group_params_1)
+    when [true, true, false]
+      @group_1 = @parent_group.children.create(@group_params_1)
+      @group_2 = @group_1.children.create(@group_params_2)
+    when [true, true, true]
+      @group_1 = @parent_group.children.create(@group_params_1)
+      @group_2 = @group_1.children.create(@group_params_2)
+      @group_3 = @group_2.children.create(@group_params_3)
     else
-      render :new
+      redirect_to new_group_path and return
     end
+    redirect_to regist_groups_path
   end
 
   def regist #グループ設定画面
@@ -52,10 +50,13 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    @parent_group = Group.find(params[:group][:id])
-    @group_params_1 = {name: params[:group][:name_1], company_id: @parent_group.company_id}
-    @group_params_2 = {name: params[:group][:name_2], company_id: @parent_group.company_id}
-    @group_params_3 = {name: params[:group][:name_3], company_id: @parent_group.company_id}
+    if params[:group][:id].empty?
+      redirect_to new_group_path
+    else
+      @parent_group = Group.find(params[:group][:id])
+      @group_params_1 = {name: params[:group][:name_1], company_id: @parent_group.company_id}
+      @group_params_2 = {name: params[:group][:name_2], company_id: @parent_group.company_id}
+      @group_params_3 = {name: params[:group][:name_3], company_id: @parent_group.company_id}
+    end
   end
-
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,74 @@
+class GroupsController < ApplicationController
+  before_action :group_params, only: [:create]
+  def new #部署登録画面
+    if current_user.groups.empty?
+      render :regist
+    end
+    @group = Group.new
+    @companies = current_user.groups
+  end
+
+  def create #部署登録
+    @group_1 = @parent_group.children.new(@group_params_1)
+    if @group_1.save
+      if @group_params_2[:name] != ""
+        @group_2 = @group_1.children.new(@group_params_2)
+        if @group_2.save
+          if @group_params_3[:name] != ""
+            @group_3 = @group_2.children.new(@group_params_3)
+            if @group_3.save
+            end
+          end
+        end
+      end
+      redirect_to regist_groups_path
+    else
+      render :new
+    end
+  end
+
+  def regist #グループ設定画面
+  end
+
+  def depart_join #部署参加画面
+  end
+
+  def depart_join_create #部署参加申請
+    group = Group.find(params[:group_id])
+    if group.update(user_ids: current_user.id)
+      redirect_to root_path
+    else
+      render :depart_join
+    end
+  end
+
+  def get_group #グループ参加画面のjs用
+    @group = Group.find(params[:group_id])
+    @group_children = @group.children
+  end
+
+  # def admin #グループ設定（管理者）
+  #   group_users = current_user.group_users.where(status: 1)
+  #   @groups = []
+  #   group_users.each do |group_user|
+  #     group = Group.find(group_user.group_id)
+  #     group.subtree.each do |group|
+  #      @groups << group
+  #     end
+  #   end
+  # end
+
+  def depart_request_create #グループ申請許可
+  end
+
+  private
+  def group_params
+    @parent_group = Group.find(params[:group][:id])
+    @group_params_1 = {name: params[:group][:name_1], company_id: @parent_group.company_id}
+    @group_params_2 = {name: params[:group][:name_2], company_id: @parent_group.company_id}
+    @group_params_3 = {name: params[:group][:name_3], company_id: @parent_group.company_id}
+  end
+
+  def depart_join_params
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -47,17 +47,6 @@ class GroupsController < ApplicationController
     @group_children = @group.children
   end
 
-  # def admin #グループ設定（管理者）
-  #   group_users = current_user.group_users.where(status: 1)
-  #   @groups = []
-  #   group_users.each do |group_user|
-  #     group = Group.find(group_user.group_id)
-  #     group.subtree.each do |group|
-  #      @groups << group
-  #     end
-  #   end
-  # end
-
   def depart_request_create #グループ申請許可
   end
 
@@ -69,6 +58,4 @@ class GroupsController < ApplicationController
     @group_params_3 = {name: params[:group][:name_3], company_id: @parent_group.company_id}
   end
 
-  def depart_join_params
-  end
 end

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -1,4 +1,5 @@
 class ThanksController < ApplicationController
+  before_action :user_group_confirmation, except: [:index]
 
   def index
     @sended_thanks = current_user.sended_thanks
@@ -63,4 +64,11 @@ class ThanksController < ApplicationController
   def thank_params
     params.require(:thank).permit(:text, :receiver_id).merge(sender_id: current_user.id)
   end
+
+  def user_group_confirmation
+    if current_user.groups.empty?
+      redirect_to regist_groups_path
+    end
+  end
+
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,9 +10,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    @user = User.new(regist_user_params)
+    if @user.save
+      sign_in(@user)
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
 
   # GET /resource/edit
   # def edit
@@ -59,4 +65,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  private
+  def regist_user_params
+    params.require(:user).permit(:avatar, :name, :email, :password, :password_confirmation, :introduction)
+  end
 end

--- a/app/javascript/components/login/LoginPassword.vue
+++ b/app/javascript/components/login/LoginPassword.vue
@@ -32,9 +32,9 @@
         </p>
         <p>
           <img class="beginner" src="~beginner_icon.svg" alt="初心者マーク">
-          <span class="resetting_pass">
-            認証がまだのかたは管理者にお問い合わせください  ︎
-          </span>
+          <a class="resetting_pass" href="/users/sign_up">
+            新規登録
+          </a>
         </p>
       </div>
     </form>
@@ -111,7 +111,7 @@ export default {
     box-sizing: border-box;
   }
   .form_content{
-    margin: 90px 0 40px; 
+    margin: 90px 0 40px;
   }
   .form_content label{
     display: inline-block;

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,23 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   belongs_to :company
   has_ancestry
+
+  def self.groups_create(group1, group2, group3)
+    
+    if @group_1.save
+      if @group_params_2[:name] != ""
+        @group_2 = @group_1.children.new(@group_params_2)
+        if @group_2.save
+          if @group_params_3[:name] != ""
+            @group_3 = @group_2.children.new(@group_params_3)
+            if @group_3.save
+            end
+          end
+        end
+      end
+      redirect_to regist_groups_path
+    else
+      render :new
+    end
+  end
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -4,6 +4,12 @@ class GroupUser < ApplicationRecord
 
   enum rank: { "メンバー": 0, "チームリーダー": 1, "拠点リーダー": 2, "チーム統括": 3, "エリアリーダー": 4, "グループリーダー": 5,
      "ユニットリーダー": 6, "秘書": 7, "内部監査担当者": 8, "新規事業担当者": 9, "代表取締役": 10, "社長": 11, "業務委託": 12, "派遣": 13, "アルバイト": 14 }
-  validates :rank,
-  inclusion: {in: GroupUser.ranks.keys}
+  # validates :rank,
+  # 　inclusion: {in: GroupUser.ranks.keys}
+
+  enum status: { "一般": 0, "管理者": 1 }
+
+  validates :status, :rank, presence: true
+  # validates :status,
+  # inclusion: {in: GroupUser.statuses.keys}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,6 @@ class User < ApplicationRecord
 
   # president: 社長, ul: ユニットリーダー, gl:グループリーダー
   # bl: エリア統括, sbl: 拠点統括, tl: チームリーダー, mem: メンバー
-  enum status: { "社員": 0, "管理者": 1 }
 
 
   # 先頭は文字列から始まり、末尾は@di-v.co.jpの形のemailを許可
@@ -37,8 +36,6 @@ class User < ApplicationRecord
   # 指定された値がenumのkeyだった場合は許可
 
   # 指定された値がenumのkeyだった場合は許可
-  validates :status,
-  inclusion: {in: User.statuses.keys}
 
 
    def email_custom_error

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -1,0 +1,8 @@
+会社画面
+<%= form_with model: @company, local: true do |f| %>
+  会社名：<%= f.text_field :name %>
+  郵便番号（任意）：<%= f.text_field :post_number %>
+  住所（任意）：<%= f.text_field :address %>
+  電話番号（任意）：<%= f.text_field :phone_number %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,13 +4,33 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :avatar %><br />
+    <%= f.file_field :avatar%>
+  </div>
+
+  <div class="field">
     <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+    <%= f.text_field :name, autocomplete: "off" %>
   </div>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :introduction %><br />
+    <%= f.text_area :introduction, autocomplete: "off" %>
   </div>
 
   <div class="actions">

--- a/app/views/groups/depart_join.html.erb
+++ b/app/views/groups/depart_join.html.erb
@@ -1,0 +1,19 @@
+部署参加
+<%= form_with url: depart_join_create_groups_path, method: :patch, local: true do |f| %>
+  <div id="depart_child1">
+    会社名：<%= f.collection_select(:group_id, Group.where(ancestry: nil), :id, :name, {prompt: "選択してください"}, {id: "depart_join_company"}) %>
+  </div>
+  <div id="depart_child2">
+
+  </div>
+  <div id="depart_child3">
+
+  </div>
+  <div id="depart_child3">
+
+  </div>
+  <div id="depart_child4">
+
+  </div>
+  <%= f.submit "管理者に申請する" %>
+<% end %>

--- a/app/views/groups/get_group.json.jbuilder
+++ b/app/views/groups/get_group.json.jbuilder
@@ -1,0 +1,6 @@
+if @group_children.present?
+  json.array!    @group_children.each do |group|
+	  json.id     group.id
+    json.name   group.name
+  end
+end

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,8 @@
+部署画面
+<%= form_with model: @group, local: true do |f| %>
+　会社名：<%= f.collection_select(:id, @companies, :id, :name, {prompt: "選択してください"}) %>
+  部署名（親）：<%= f.text_field :name_1 %>
+  部署名（子）：<%= f.text_field :name_2 %>
+  部署名（孫）：<%= f.text_field :name_3 %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/groups/regist.html.erb
+++ b/app/views/groups/regist.html.erb
@@ -1,0 +1,3 @@
+<%= link_to "会社を登録する", new_company_path %>
+<%= link_to "グループを作る", new_group_path %>
+<%= link_to "グループに参加する", depart_join_groups_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,16 @@ Rails.application.routes.draw do
       delete 'image/destroy', to: "users#image_destroy"
     end
   end
+
+  resources :companies, only: [:new, :create]
+  resources :groups, only: [:new, :create] do
+    collection do
+      get "regist", to: "groups#regist"
+      get "depart_join", to: "groups#depart_join"
+      get "get_group", to: "groups#get_group"
+      get "admin",   to: "groups#admin"
+      patch "depart_join_create", to: "groups#depart_join_create"
+      patch "depart_request_create", to: "groups#depart_request_create"
+    end
+  end
 end

--- a/db/migrate/20200204060443_devise_create_users.rb
+++ b/db/migrate/20200204060443_devise_create_users.rb
@@ -6,7 +6,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string  :name,               null: false
       t.string  :email,              null: false, default: ""
       t.text    :introduction
-      t.integer :status,             null: false, default: 0
       t.string  :avatar
 
       ## Database authenticatable

--- a/db/migrate/20200210154315_create_group_users.rb
+++ b/db/migrate/20200210154315_create_group_users.rb
@@ -5,6 +5,8 @@ class CreateGroupUsers < ActiveRecord::Migration[5.2]
       t.references :user, foreign_key: true
       t.integer :rank, null: false, default: 0
       t.boolean    :enrollment, null: false, default: true
+      t.integer :status,             null: false, default: 0
+      t.boolean :request, null: false, default: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 2020_03_17_034434) do
     t.bigint "user_id"
     t.integer "rank", default: 0, null: false
     t.boolean "enrollment", default: true, null: false
+    t.integer "status", default: 0, null: false
+    t.boolean "request", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_group_users_on_group_id"
@@ -109,7 +111,6 @@ ActiveRecord::Schema.define(version: 2020_03_17_034434) do
     t.string "name", null: false
     t.string "email", default: "", null: false
     t.text "introduction"
-    t.integer "status", default: 0, null: false
     t.string "avatar"
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
#WHY
- ユーザー自身でアカウント作成を行うため
- 今後の展開を考えた際に、ユーザー自身でアカウント登録できた方が幅が広がるため

#WHAT
１、トップページでユーザー新規登録ボタンを用意
- 新規ボタン追加のみのためチェックは無し

２、ユーザー登録機能
- [ ] app/controllers/users/registrations_controller.rbにて実装記述ミスは無いか

３、グループ設定画面
- 画面表示のみのためチェック無し

４、会社新規作成機能
- [ ] app/controllers/companies_controller.rbにて実装、記述ミスが無いか
- [ ] company（会社）登録時にgroup（部署「会社名」）も同時生成しているが問題無いか

５、部署新規作成機能（ユーザーが所属している会社が無い場合はグループ設定画面にリダイレクト）
- [ ] app/controllers/groups_controller.rbのnew,createにて実装、記述ミスは無いか
- [ ] current_userが所属（管理者として所属）している部署がなければ、renderでグループ設定画面に遷移させる
- [ ] 部署（親、子、孫）が多階層で保存できる

６、部署参加機能
- [ ] app/controllers/groups_controller.rbにて実装、記述ミスが無いか
- [ ] 現状、申請を送るとgroup_usersテーブルにrequestカラムfalseで保存される、管理者ページではこのrequestを許可であればtrue、却下であれば削除する機能を追加する必要がある
- [ ] app/assets/javascripts/depart_join.jsにて選択肢にひもづく子要素を表示

７、その他変更箇所
- [ ] dbでusersテーブルからstatusカラムを削除し、group_usersテーブルにstatusカラムを追加
- [ ] モデルにてuserモデルからenum statusをgroup_userモデルに移動
- [ ] dbにてgroup_usersテーブルにrequestカラムを追加、申請許可用のカラム