### PR TITLE
Feature/receive_thanks_API

### DIFF
--- a/app/controllers/letters/receive_controller.rb
+++ b/app/controllers/letters/receive_controller.rb
@@ -1,16 +1,60 @@
 class Letters::ReceiveController < ApplicationController
   def index
-    user = User.find(params[:user_id])
-    @received_thanks = user.received_thanks
-    @receive_thanks = []
-    @senders = []
-    @received_thanks.each do |receive_thank|
-      @receive_thanks << receive_thank
-      @senders   << receive_thank.sender.name
-    end
-    respond_to do |format|
-      format.html
-      format.json
+    @user = User.find(params[:user_id])
+    # 受信一覧を取得したいというリクエストが来た時だけ発火
+    if params["receive_year"]
+      # 検索したい日付を定義
+      search_date = params["receive_year"] + "-" + params["receive_month"] +  "-" + "01"
+      # 受信したありレターを作成日ベースで検索
+      received_thanks = @user.received_thanks.where(created_at: search_date.in_time_zone.all_month)
+      # 受信したデータをVueに渡すために加工
+      @received_thanks = []
+      received_thanks.each do |received_thank|
+        @received_thanks.push(
+          {
+            id: received_thank.id,
+            text: received_thank.text,
+            sender: {
+              id: received_thank.sender.id,
+              family_name: received_thank.sender.family_name,
+              given_name: received_thank.sender.given_name,
+              avatar: received_thank.sender.avatar
+            },
+            transmission_status: received_thank.transmission,
+            reception_status: received_thank.reception_status
+          }
+        )
+      end
+      respond_to do |format|
+        format.html
+        format.json
+      end
     end
   end
 end
+# 仮の日付
+# search_date = '2016-1-25'
+
+# 年での指定
+# Item.where(created_at: search_date.in_time_zone.all_year)
+
+# 月での指定
+# Item.where(created_at: search_date.in_time_zone.all_month)
+
+# 日での指定
+# Item.where(created_at: search_date.in_time_zone.all_day)
+# User.where(created_at: search_date.all_month)
+# -- 年での指定
+# SELECT "items".* 
+# FROM "items"  
+# WHERE ("items"."created_at" BETWEEN '2016-01-01 00:00:00' AND '2016-12-31 23:59:59')
+
+# -- 月での指定
+# SELECT "items".* 
+# FROM "items"  
+# WHERE ("items"."created_at" BETWEEN '2016-01-01 00:00:00' AND '2016-01-31 23:59:59')
+
+# -- 日での指定
+# SELECT "items".* 
+# FROM "items"  
+# WHERE ("items"."created_at" BETWEEN '2016-01-25 00:00:00' AND '2016-01-25 23:59:59')

--- a/app/javascript/components/letters/receive/Receive.vue
+++ b/app/javascript/components/letters/receive/Receive.vue
@@ -18,18 +18,6 @@ export default {
     return {
       mypageNav: "receive"
     }
-  },
-  created: function(){
-    axios.defaults.headers.common = {
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-    };    
-
-    axios
-      .get('/thanks.json')
-      .then(response => {
-        this.$data.current_user = response.data.current_user
-      });
   }
 }
 </script>

--- a/app/javascript/components/letters/receive/ReceiveContents.vue
+++ b/app/javascript/components/letters/receive/ReceiveContents.vue
@@ -101,7 +101,7 @@ export default {
           .get(url, {
             params: {
               receive_year: this.$data.receive.year,
-              receive_month: this.$data.receive.month
+              receive_month: this.$data.receive.month 
             }
           })
           .then( response => {
@@ -171,7 +171,7 @@ export default {
     // 年月の取得
     var now = new Date();
     this.$data.receive.year = now.getFullYear()
-    this.$data.receive.month = now.getMonth()
+    this.$data.receive.month = now.getMonth() + 1
     // 受信したありレターの取得
     axios.defaults.headers.common = {
       'X-Requested-With': 'XMLHttpRequest',

--- a/app/javascript/components/letters/receive/ReceiveContents.vue
+++ b/app/javascript/components/letters/receive/ReceiveContents.vue
@@ -36,79 +36,158 @@ export default {
     return {
       // ありレターの数はlength、senderとtextも入っている。
       thanks: [
-        {
-          id: "",
-          text:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          sender: {
-            id: "",
-            family_name: "熊谷",
-            given_name: "真理子",
-            avatar: "test.jpeg"
-          },
-          reception_status: "0"
-        },
-        {
-          id: "",
-          text:"testtesttesttest",
-          sender: {
-            id: "",
-            family_name: "熊谷",
-            given_name: "隆太郎",
-            avatar: "test.jpeg"
-          },
-          reception_status: "1"
-        },
-        {
-          id: "",
-          text:"いつもありがとう",
-          sender: {
-            id: "",
-            family_name: "奥脇",
-            given_name: "真人",
-            avatar: "test.jpeg"
-          },
-          reception_status: "1"
-        },
-        {
-          id: "",
-          text:"testtesttesttest",
-          sender: {
-            id: "",
-            family_name: "長松軒",
-            given_name: "昇悟",
-            avatar: "test.jpeg"
-          },
-          reception_status: "1"
-        }
+        // {
+        //   id: "",
+        //   text:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        //   sender: {
+        //     id: "",
+        //     family_name: "熊谷",
+        //     given_name: "真理子",
+        //     avatar: "test.jpeg"
+        //   },
+        //   reception_status: "0"
+        // },
+        // {
+        //   id: "",
+        //   text:"testtesttesttest",
+        //   sender: {
+        //     id: "",
+        //     family_name: "熊谷",
+        //     given_name: "隆太郎",
+        //     avatar: "test.jpeg"
+        //   },
+        //   reception_status: "1"
+        // },
+        // {
+        //   id: "",
+        //   text:"いつもありがとう",
+        //   sender: {
+        //     id: "",
+        //     family_name: "奥脇",
+        //     given_name: "真人",
+        //     avatar: "test.jpeg"
+        //   },
+        //   reception_status: "1"
+        // },
+        // {
+        //   id: "",
+        //   text:"testtesttesttest",
+        //   sender: {
+        //     id: "",
+        //     family_name: "長松軒",
+        //     given_name: "昇悟",
+        //     avatar: "test.jpeg"
+        //   },
+        //   reception_status: "1"
+        // }
       ],
       receive: {
-        year: "2020",
-        month: "6"
+        year: "",
+        month: ""
       }
-    }
-  },
-  computed: {
-    user_name: () => {
-      return ""
     }
   },
   methods: {
     increClick: function(){
+      // 12月じゃなかったらそのまま月を変更。変更した月で受信したありレターを取得する。
       if(this.receive.month < 12 ){
-        return this.receive.month++
+        this.receive.month++
+          axios.defaults.headers.common = {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+          };
+          var url = location.pathname + ".json"
+          axios
+          .get(url, {
+            params: {
+              receive_year: this.$data.receive.year,
+              receive_month: this.$data.receive.month
+            }
+          })
+          .then( response => {
+            this.$data.thanks = response.data.receive_thanks
+          })
       }else{
+      // 12月じゃなかったらそのまま月を変更。変更した月で受信したありレターを取得する。
         this.receive.year++
-        return this.receive.month = 1
+        this.receive.month = 1
+          axios.defaults.headers.common = {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+          };
+          var url = location.pathname + ".json"
+          axios
+          .get(url, {
+            params: {
+              receive_year: this.$data.receive.year,
+              receive_month: this.$data.receive.month
+            }
+          })
+          .then( response => {
+            this.$data.thanks = response.data.receive_thanks
+          })
       }
     },
     decreClick: function(){
       if(this.receive.month > 1){
-        return this.receive.month--
+        this.receive.month--
+          axios.defaults.headers.common = {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+          };
+          var url = location.pathname + ".json"
+          axios
+          .get(url, {
+            params: {
+              receive_year: this.$data.receive.year,
+              receive_month: this.$data.receive.month
+            }
+          })
+          .then( response => {
+            this.$data.thanks = response.data.receive_thanks
+          })
       }else{
         this.receive.year--
-        return this.receive.month = 12
+        this.receive.month = 12
+          axios.defaults.headers.common = {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+          };
+          var url = location.pathname + ".json"
+          axios
+          .get(url, {
+            params: {
+              receive_year: this.$data.receive.year,
+              receive_month: this.$data.receive.month
+            }
+          })
+          .then( response => {
+            this.$data.thanks = response.data.receive_thanks
+          })
       }
     }
+  },
+  created(){
+    // 年月の取得
+    var now = new Date();
+    this.$data.receive.year = now.getFullYear()
+    this.$data.receive.month = now.getMonth()
+    // 受信したありレターの取得
+    axios.defaults.headers.common = {
+      'X-Requested-With': 'XMLHttpRequest',
+      'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    };
+    var url = location.pathname + ".json"
+    axios
+    .get(url, {
+      params: {
+        receive_year: this.$data.receive.year,
+        receive_month: this.$data.receive.month
+      }
+    })
+    .then( response => {
+      this.$data.thanks = response.data.receive_thanks
+    })
   }
 }
 </script>
@@ -161,11 +240,13 @@ main{
 
 .countbox_title{
   padding: 10px;
+  width: 250px;
 }
 
 .countbox_num{
   border-left: 1px solid #ff0000;
   padding: 10px;
+  width: 50px;
 }
 
 .contents{

--- a/app/javascript/components/shared/Header.vue
+++ b/app/javascript/components/shared/Header.vue
@@ -48,7 +48,7 @@ export default {
         }
       },
       company:{
-        name: "まだ登録されていません"
+        name: ""
       }
     }
   },
@@ -58,6 +58,8 @@ export default {
     .then(response =>{
       if(response.data[0].company.name){
         this.$data.company.name = response.data[0].company.name
+      }else {
+        this.$data.company.name = "まだ登録されていません"
       }
     });
   },

--- a/app/views/letters/receive/index.json.jbuilder
+++ b/app/views/letters/receive/index.json.jbuilder
@@ -1,2 +1,1 @@
-json.receive_thanks @receive_thanks
-json.senders @senders
+json.receive_thanks @received_thanks


### PR DESCRIPTION
# WHAT
- 受信一覧ページの今月受け取った数のCSSを送信一覧のものと一致。
- 受信一覧ページを取得した時点の日付をビューに反映。
- 受信一覧ページを取得した時点の受信したありレターを表示。
- 日付を移動したらそれに合わせて受信一覧が変更。

# 仕様
- [ ] 受信一覧ページを取得した時点の日付で一覧表示
①受信一覧を表示するコンポーネント ReceiveContents.vueが生成される。
②createdメソッドにて現在日付を取得。リアクティブデータに反映。
③リアクティブデータに反映させた日付を元に、railsのletters::receive#indexにリクエストを送信。paramsに日付を格納。
④letters::receive#indexにてDBからparamsに格納された日付を元に受信一覧を月単位/作成日ベースで取得。
⑤vueにレスポンスを返し、リアクティブデータに反映。

- [ ] 日付を移動したらそれに合わせて受信一覧が変更。
①クリックしたら日付をリアクティブデータに反映。
②リアクティブデータに反映させた日付を元に、railsのletters::receive#indexにリクエストを送信。paramsに日付を格納。
③letters::receive#indexにてDBからparamsに格納された日付を元に受信一覧を月単位/作成日ベースで取得。
④vueにレスポンスを返し、リアクティブデータに反映。

# Check
- [ ] 文法ミスがないか？
- [ ] 冗長になっているコードはないか？
- [ ] 新規作成のポップアップ作成にあたりコンフリクトが生じそうな部分はないか。

# 相談
- [ ] ページが切り替わる度に新規作成ボタンが一回一回DOMが読まれているせいかCSSの反映にズレがあって気持ち悪いのでコンポーネント化したい。
- [ ] その他、受信一覧や送信一覧も合わせて今後コンポーネント化して管理したい。