### PR TITLE
Feature/create send_API

### DIFF
--- a/app/controllers/letters/send_controller.rb
+++ b/app/controllers/letters/send_controller.rb
@@ -1,4 +1,34 @@
 class Letters::SendController < ApplicationController
-  def index
+ def index
+    @user = User.find(params[:user_id])
+    # 送信一覧を取得したいというリクエストが来た時だけ発火
+    if params["send_year"]
+      # 検索したい日付を定義
+      search_date = params["send_year"] + "-" + params["send_month"] +  "-" + "01"
+      # 送信したありレターを作成日ベースで検索
+      send_thanks = @user.sended_thanks.where(created_at: search_date.in_time_zone.all_month)
+      # 送信したデータをVueに渡すために加工
+      @send_thanks = []
+      send_thanks.each do |send_thank|
+        @send_thanks.push(
+          {
+            id: send_thank.id,
+            text: send_thank.text,
+            sender: {
+              id: send_thank.sender.id,
+              family_name: send_thank.sender.family_name,
+              given_name: send_thank.sender.given_name,
+              avatar: send_thank.sender.avatar
+            },
+            transmission_status: send_thank.transmission,
+            reception_status: send_thank.reception_status
+          }
+        )
+      end
+      respond_to do |format|
+        format.html
+        format.json
+      end
+    end
   end
 end

--- a/app/javascript/components/letters/send/Send.vue
+++ b/app/javascript/components/letters/send/Send.vue
@@ -18,18 +18,6 @@ export default {
     return {
       mypageNav: "send"
     }
-  },
-  created: function(){
-    axios.defaults.headers.common = {
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-    };    
-
-    axios
-      .get('/thanks.json')
-      .then(response => {
-        this.$data.current_user = response.data.current_user
-      });
   }
 }
 </script>

--- a/app/javascript/components/letters/send/SendContents.vue
+++ b/app/javascript/components/letters/send/SendContents.vue
@@ -92,10 +92,32 @@ export default {
         }
       ],
       send: {
-        year: "2020",
-        month: "6"
+        year: "",
+        month: ""
       }
     }
+  },
+  created(){
+    // 年月の取得
+    var now = new Date();
+    this.$data.send.year = now.getFullYear()
+    this.$data.send.month = now.getMonth() + 1
+    // 受信したありレターの取得
+    axios.defaults.headers.common = {
+      'X-Requested-With': 'XMLHttpRequest',
+      'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    };
+    var url = location.pathname + ".json"
+    axios
+    .get(url, {
+      params: {
+        send_year: this.$data.send.year,
+        send_month: this.$data.send.month
+      }
+    })
+    .then( response => {
+      this.$data.thanks = response.data.send_thanks
+    })
   },
   computed: {
     thanks_edit_count: function(){
@@ -127,18 +149,78 @@ export default {
   methods: {
     increClick: function(){
       if(this.send.month < 12 ){
-        return this.send.month++
+        this.send.month++
+        axios.defaults.headers.common = {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+        };
+        var url = location.pathname + ".json"
+        axios
+        .get(url, {
+          params: {
+            send_year: this.$data.send.year,
+            send_month: this.$data.send.month
+          }
+        })
+        .then( response => {
+          this.$data.thanks = response.data.send_thanks
+        })
       }else{
         this.send.year++
-        return this.send.month = 1
-      }
+        this.send.month = 1
+        axios.defaults.headers.common = {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+        };
+        var url = location.pathname + ".json"
+        axios
+        .get(url, {
+          params: {
+            send_year: this.$data.send.year,
+            send_month: this.$data.send.month
+          }
+        })
+        .then( response => {
+          this.$data.thanks = response.data.send_thanks
+        })
+}
     },
     decreClick: function(){
       if(this.send.month > 1){
-        return this.send.month--
+        this.send.month--
+        axios.defaults.headers.common = {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+        };
+        var url = location.pathname + ".json"
+        axios
+        .get(url, {
+          params: {
+            send_year: this.$data.send.year,
+            send_month: this.$data.send.month
+          }
+        })
+        .then( response => {
+          this.$data.thanks = response.data.send_thanks
+        })
       }else{
         this.send.year--
-        return this.send.month = 12
+        this.send.month = 12
+        axios.defaults.headers.common = {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-TOKEN' : document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+        };
+        var url = location.pathname + ".json"
+        axios
+        .get(url, {
+          params: {
+            send_year: this.$data.send.year,
+            send_month: this.$data.send.month
+          }
+        })
+        .then( response => {
+          this.$data.thanks = response.data.send_thanks
+        })
       }
     }
   }

--- a/app/views/letters/send/index.json.jbuilder
+++ b/app/views/letters/send/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.send_thanks @send_thanks


### PR DESCRIPTION
# WHAT
- 送信一覧ページを取得した時点の日付をビューに反映。
- 送信一覧ページを取得した時点の送信したありレターを表示。
- 日付を移動したらそれに合わせて送信一覧が変更。

# 仕様
- [ ] 送信一覧ページを取得した時点の日付で一覧表示
①送信一覧を表示するコンポーネント SendContents.vueが生成される。
②createdメソッドにて現在日付を取得。リアクティブデータに反映。
③リアクティブデータに反映させた日付を元に、railsのletters::send#indexにリクエストを送信。paramsに日付を格納。
④letters::send#indexにてDBからparamsに格納された日付を元に送信一覧を月単位/作成日ベースで取得。
⑤vueにレスポンスを返し、リアクティブデータに反映。

- [ ] 日付を移動したらそれに合わせて送信一覧が変更。
①クリックしたら日付をリアクティブデータに反映。
②リアクティブデータに反映させた日付を元に、railsのletters::send#indexにリクエストを送信。paramsに日付を格納。
③letters::send#indexにてDBからparamsに格納された日付を元に送信一覧を月単位/作成日ベースで取得。
④vueにレスポンスを返し、リアクティブデータに反映。

# Check
- [ ] 文法ミスがないか？
- [ ] 冗長になっているコードはないか？
- [ ] 新規作成のポップアップ作成にあたりコンフリクトが生じそうな部分はないか。
