### PR TITLE
UserモデルのRspecテスト

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "#create" do
+    let(:user) { build(:user) }
+
+    context "値が正しい場合" do
+      it "全てのカラム情報が正しいこと" do
+        expect(user).to be_valid
+      end
+      it "DBにレコードが保存されること" do
+        expect{ user.save }.to change{ User.count }
+      end
+
+      context "正規表現によるバリデーション動作が正しい場合" do
+
+        it "passwordカラムに設定した正規表現のバリデーションが正しく動作していること" do
+          user.password, user.password_confirmation = create_random_string(0, 6)
+          expect(user).to be_valid
+        end
+
+        it "emailを小文字に変換後の値と大文字を混ぜて登録されたアドレスが同じ文字列であること" do
+          user.email = "Foo@ExAMPle.CoM"
+          user.save
+          expect(user.reload.email).to eq "foo@example.com"
+        end
+      end
+    end
+
+    context "値が不正な場合" do
+      context "カラムの値が空でエラーが発生する場合" do
+        it "family_nameカラムが空であること" do
+          user.family_name = nil
+          user.valid?
+          expect(user.errors[:family_name]).to include("を入力してください")
+        end
+
+        it "given_nameカラムが空であること" do
+          user.given_name = nil
+          user.valid?
+          expect(user.errors[:given_name]).to include("を入力してください")
+        end
+
+        it "emailカラムが空であること" do
+          user.email = nil
+          user.valid?
+          expect(user.errors[:email]).to include("を入力してください")
+        end
+
+        it "passwordカラムが空であること" do
+          user.password = nil
+          user.valid?
+          expect(user.errors[:password]).to include("を入力してください")
+        end
+
+        it "password_confirmationカラムが空であること" do
+          user.password_confirmation = ""
+          user.valid?
+          expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
+        end
+      end
+
+      context "email_custom_errorメソッドが実行される場合" do
+        it "emailが空であること" do
+          user.email = nil
+          user.valid?
+          expect(user.email.blank?).to be true
+          expect(user.errors[:email]).to include("を入力してください")
+        end
+        it "emailに設定した正規表現のバリデーションが正しく動作していること" do
+          addresses = %w[user@foo,com user_at_foo.org example.user@foo.foo@bar_baz.com foo@bar+baz.com foo@bar..com]
+          addresses.each do |invalid_address|
+            user.email = addresses
+            user.valid?
+            expect(user).to be_invalid
+            expect(user.errors[:email]).to include("は不適切な値です")
+          end
+        end
+      end
+
+      it "passwordカラムに代入されている値が5文字だと保存できないこと" do
+        user.password, user.password_confirmation = create_random_string(0, 5)
+        user.valid?
+        expect(user.errors[:password]).to include("は6文字以上で入力してください")
+      end
+
+      it "重複したemailはDBに保存できないこと" do
+        user.save
+        another_user = build(:user, email: user.email)
+        another_user.valid?
+        expect(another_user.errors[:email]).to include("はすでに存在します")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -34,6 +34,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include CreateRandomString
 
   Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
   config.include Devise::Test::ControllerHelpers, type: :controller

--- a/spec/support/user_support.rb
+++ b/spec/support/user_support.rb
@@ -1,0 +1,8 @@
+module CreateRandomString
+  def create_random_string(start_number, end_number)
+    tmp = [('a'..'z'), ('0'..'9')].map { |i| i.to_a }.flatten
+    string = (start_number...end_number).map { tmp[rand(tmp.length)] }.join
+    return string
+  end
+
+end


### PR DESCRIPTION
# 概要
以下、Userモデルテストの詳細を記載します。
## 実装内容
以下の事象をテストコードにより確認した（全部で13のテストを実施）。

**値が正しい場合**
- 全てのカラム情報が正しいこと
- DBにレコードが保存されること
- passwordカラムに設定した正規表現のバリデーションが正しく動作していること
- emailを小文字に変換後の値と大文字を混ぜて登録されたアドレスが同じ文字列であること

**値が不正の場合**
- カラムの値が空でエラーが発生する場合
- email_custom_errorメソッドが実行される場合
- passwordカラムに代入されている値が5文字だと保存できないこと
- 重複したemailはDBに保存できないこと

## 実装コード

```ruby
require "rails_helper"

RSpec.describe User, type: :model do
  describe "#create" do
    let(:user) { build(:user) }

    context "値が正しい場合" do
      it "全てのカラム情報が正しいこと" do
        expect(user).to be_valid
      end
      it "DBにレコードが保存されること" do
        expect{ user.save }.to change{ User.count }
      end

      context "正規表現によるバリデーション動作が正しい場合" do

        it "passwordカラムに設定した正規表現のバリデーションが正しく動作していること" do
          user.password, user.password_confirmation = create_random_string(0, 6)
          expect(user).to be_valid
        end

        it "emailを小文字に変換後の値と大文字を混ぜて登録されたアドレスが同じ文字列であること" do
          user.email = "Foo@ExAMPle.CoM"
          user.save
          expect(user.reload.email).to eq "foo@example.com"
        end
      end
    end

    context "値が不正な場合" do
      context "カラムの値が空でエラーが発生する場合" do
        it "family_nameカラムが空であること" do
          user.family_name = nil
          user.valid?
          expect(user.errors[:family_name]).to include("を入力してください")
        end

        it "given_nameカラムが空であること" do
          user.given_name = nil
          user.valid?
          expect(user.errors[:given_name]).to include("を入力してください")
        end

        it "emailカラムが空であること" do
          user.email = nil
          user.valid?
          expect(user.errors[:email]).to include("を入力してください")
        end

        it "passwordカラムが空であること" do
          user.password = nil
          user.valid?
          expect(user.errors[:password]).to include("を入力してください")
        end

        it "password_confirmationカラムが空であること" do
          user.password_confirmation = ""
          user.valid?
          expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
        end
      end

      context "email_custom_errorメソッドが実行される場合" do
        it "emailが空であること" do
          user.email = nil
          user.valid?
          expect(user.email.blank?).to be true
          expect(user.errors[:email]).to include("を入力してください")
        end
        it "emailに設定した正規表現のバリデーションが正しく動作していること" do
          addresses = %w[user@foo,com user_at_foo.org example.user@foo.foo@bar_baz.com foo@bar+baz.com foo@bar..com]
          addresses.each do |invalid_address|
            user.email = addresses
            user.valid?
            expect(user).to be_invalid
            expect(user.errors[:email]).to include("は不適切な値です")
          end
        end
      end

      it "passwordカラムに代入されている値が5文字だと保存できないこと" do
        user.password, user.password_confirmation = create_random_string(0, 5)
        user.valid?
        expect(user.errors[:password]).to include("は6文字以上で入力してください")
      end

      it "重複したemailはDBに保存できないこと" do
        user.save
        another_user = build(:user, email: user.email)
        another_user.valid?
        expect(another_user.errors[:email]).to include("はすでに存在します")
      end
    end
  end
end
```
## 実装結果

```bash
 rspec spec/models/user_spec.rb 
WARN: Unresolved specs during Gem::Specification.reset:
      diff-lcs (< 2.0, >= 1.2.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
2020-07-21 02:02:23 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

User
  #create
    値が正しい場合
      全てのカラム情報が正しいこと
      DBにレコードが保存されること
      正規表現によるバリデーション動作が正しい場合
        passwordカラムに設定した正規表現のバリデーションが正しく動作していること
        emailを小文字に変換後の値と大文字を混ぜて登録されたアドレスが同じ文字列であること
    値が不正な場合
      passwordカラムに代入されている値が5文字だと保存できないこと
      重複したemailはDBに保存できないこと
      カラムの値が空でエラーが発生する場合
        family_nameカラムが空であること
        given_nameカラムが空であること
        emailカラムが空であること
        passwordカラムが空であること
        password_confirmationカラムが空であること
      email_custom_errorメソッドが実行される場合
        emailが空であること
        emailに設定した正規表現のバリデーションが正しく動作していること

Finished in 0.77328 seconds (files took 6.21 seconds to load)
13 examples, 0 failures

```

## 特に確認してほしい箇所
- リリースに必須のテストは全て実施できているか
- contextの切り分けは自然か
- 不要なテストはないか
- 以下の警告は解決すべきか
```bash
WARN: Unresolved specs during Gem::Specification.reset:
      diff-lcs (< 2.0, >= 1.2.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
2020-07-21 02:02:23 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
```

