### PR TITLE
group_userテーブル最低限のテスト実装

### DIFF
--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -10,6 +10,7 @@ class GroupUser < ApplicationRecord
   enum status: { "一般": 0, "管理者": 1 }
 
   validates :status, :rank, presence: true
+  validates :group_id, :uniqueness => { :scope => :user_id }
   # validates :status,
   # inclusion: {in: GroupUser.statuses.keys}
 end

--- a/spec/factories/group_users.rb
+++ b/spec/factories/group_users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :group_user do
-    group
-    user
+    association :user
+    association :group
     rank {0}
     status {0}
     enrollment {true}

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe GroupUser, type: :model do
           member.valid?
           expect(member.errors[:status]).to include("を入力してください")
         end
-        it '同じ組み合わせがDBに保存されるとき' do
-          member.save
-          another_member = build(:group_user, user: user, group: group)
-          another_member.valid?
-          expect(member.errors[:group_id]).to include("はすでに存在します")
-        end
+      end
+      it '同じ組み合わせのuser_idとgroup_idがDBに保存されるとき' do
+        member.save
+        another_member = build(:group_user, user: user, group: group)
+        another_member.valid?
+        expect(member.errors[:group_id]).to include("はすでに存在します")
       end
     end
   end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe GroupUser, type: :model do
+  describe '#create' do
+    let(:user) {create(:user)}
+    let(:group) { create(:group) }
+    let(:member) { create(:group_user, user: user, group: group) }
+
+    context "値が正しい場合" do
+      it 'group_user生成に紐づいてuserとgroupが生成されていること' do
+        expect(member.user.present?).to be true
+        expect(member.group.present?).to be true
+      end
+      it '外部キーを用いて中間テーブルの作成に成功していること' do
+        expect {
+          member.save
+        }.to change{ GroupUser.count }.by(1)
+      end
+      context '中間テーブルに保存されている外部キーが正しい場合' do
+        it 'user_idの値が正しい場合' do
+          expect(member.user.id).to eq user.id
+        end
+        it 'group_idの値が正しい場合' do
+          expect(member.group.id).to eq group.id
+        end
+      end
+    end
+
+    context "値が不正の場合" do
+      context "特定のカラムが空の場合" do
+        it "rankカラムが空であること" do
+          member.rank = nil
+          member.valid?
+          expect(member.errors[:rank]).to include("を入力してください")
+        end
+        it "statusカラムが空であること" do
+          member.status = nil
+          member.valid?
+          expect(member.errors[:status]).to include("を入力してください")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GroupUser, type: :model do
   describe '#create' do
     let(:user) {create(:user)}
     let(:group) { create(:group) }
-    let(:member) { create(:group_user, user: user, group: group) }
+    let(:member) { build(:group_user, user: user, group: group) }
 
     context "値が正しい場合" do
       it 'group_user生成に紐づいてuserとgroupが生成されていること' do
@@ -37,6 +37,12 @@ RSpec.describe GroupUser, type: :model do
           member.status = nil
           member.valid?
           expect(member.errors[:status]).to include("を入力してください")
+        end
+        it '同じ組み合わせがDBに保存されるとき' do
+          member.save
+          another_member = build(:group_user, user: user, group: group)
+          another_member.valid?
+          expect(member.errors[:group_id]).to include("はすでに存在します")
         end
       end
     end


### PR DESCRIPTION
# 概要
group_usersテーブルに関連する必要最低限のRspecテストを実装

## 実装内容
以下の6つのテストを実装

- 値が正しい場合
  - group_user生成に紐づいてuserとgroupが生成されているこ
  - 外部キーを用いて中間テーブルの作成に成功していること
  - 中間テーブルに保存されている外部キーが正しい場合
    - user_idの値が正しい場合
    - group_idの値が正しい場合

- 値が不正の場合
  - 特定のカラムが空の場合
    - rankカラムが空であること
    - statusカラムが空であること

##  実装したソースコード

**spec/models/group_user_spec.rb**
```js
require 'rails_helper'

RSpec.describe GroupUser, type: :model do
  describe '#create' do
    let(:user) {create(:user)}
    let(:group) { create(:group) }
    let(:member) { create(:group_user, user: user, group: group) }

    context "値が正しい場合" do
      it 'group_user生成に紐づいてuserとgroupが生成されていること' do
        expect(member.user.present?).to be true
        expect(member.group.present?).to be true
      end
      it '外部キーを用いて中間テーブルの作成に成功していること' do
        expect {
          member.save
        }.to change{ GroupUser.count }.by(1)
      end
      context '中間テーブルに保存されている外部キーが正しい場合' do
        it 'user_idの値が正しい場合' do
          expect(member.user.id).to eq user.id
        end
        it 'group_idの値が正しい場合' do
          expect(member.group.id).to eq group.id
        end
      end
    end

    context "値が不正の場合" do
      context "特定のカラムが空の場合" do
        it "rankカラムが空であること" do
          member.rank = nil
          member.valid?
          expect(member.errors[:rank]).to include("を入力してください")
        end
        it "statusカラムが空であること" do
          member.status = nil
          member.valid?
          expect(member.errors[:status]).to include("を入力してください")
        end
      end
    end
  end
end
```

## 実装結果
**rspec spec/models/group_user_spec.rbの実行結果**

```bssh
A-118:ThanksApp tech-camp$ rspec spec/models/group_user_spec.rb 
WARN: Unresolved specs during Gem::Specification.reset:
      diff-lcs (< 2.0, >= 1.2.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
2020-07-24 17:10:08 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

GroupUser
  #create
    値が正しい場合
      group_user生成に紐づいてuserとgroupが生成されていること
      外部キーを用いて中間テーブルの作成に成功していること
      中間テーブルに保存されている外部キーが正しい場合
        user_idの値が正しい場合
        group_idの値が正しい場合
    値が不正の場合
      特定のカラムが空の場合
        rankカラムが空であること
        statusカラムが空であること

Finished in 0.84103 seconds (files took 5.7 seconds to load)
6 examples, 0 failures

```

## 特に確認して欲しい箇所
- 他にテストが必要な箇所はないか
- 不必要なテストを実装していないか
- 冗長な記述はないか