### PR TITLE
recommit_group_model

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,24 +4,24 @@ class Group < ApplicationRecord
   belongs_to :company
   has_ancestry
 
-  def self.groups_create(group1, group2, group3)
+  # def self.groups_create(group1, group2, group3)
     
-    if @group_1.save
-      if @group_params_2[:name] != ""
-        @group_2 = @group_1.children.new(@group_params_2)
-        if @group_2.save
-          if @group_params_3[:name] != ""
-            @group_3 = @group_2.children.new(@group_params_3)
-            if @group_3.save
-            end
-          end
-        end
-      end
-      redirect_to regist_groups_path
-    else
-      render :new
-    end
-  end
+  #   if @group_1.save
+  #     if @group_params_2[:name] != ""
+  #       @group_2 = @group_1.children.new(@group_params_2)
+  #       if @group_2.save
+  #         if @group_params_3[:name] != ""
+  #           @group_3 = @group_2.children.new(@group_params_3)
+  #           if @group_3.save
+  #           end
+  #         end
+  #       end
+  #     end
+  #     redirect_to regist_groups_path
+  #   else
+  #     render :new
+  #   end
+  # end
 
   def data_custom(groups, company, parent_group, child_group, grandchild_group)
     group = { company: {name: company&.name,id: company&.id},

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  let(:group) { build(:group)}
+  describe "#create" do
+    context "保存できる"  do
+      it "名前がある" do
+        group.valid?
+        expect(group).to be_valid
+      end
+    end
+
+    context "保存できない" do
+      it "名前が入力されていない" do
+        no_name_group = build(:group, name: nil)
+        no_name_group.valid?
+        expect(no_name_group.errors[:name]).to include("を入力してください")
+      end
+    end
+  end
+
+  describe "ancestryが正しく機能する" do
+    context "階層ごとにgroupが保存できる" do
+      it "rootがcompanyと同じもので登録されている" do
+        root_group = create(:group)
+        expect(root_group.depth).to eq 0
+      end
+
+      it "親部署が登録できる" do
+        root_group = create(:group, :have_parent)
+        parent_group =  root_group.children[0]  
+        expect(parent_group.depth).to eq 1
+      end
+
+      it "子部署部署が登録できる" do
+        root_group = create(:group, :have_child)
+        child_group =  root_group.children[0].children[0]  
+        expect(child_group.depth).to eq 2
+      end
+
+      it "孫部署が登録できる" do
+        root_group = create(:group, :have_grand_child)
+        grand_child_group =  root_group.children[0].children[0].children[0] 
+        expect(grand_child_group.depth).to eq 3
+      end
+    end
+
+  end
+
+  describe "data_customメソッド" do
+    let(:company){create(:company)}
+    context "値が正しく返ってくる" do
+      it "companyが渡されていた時に会社の情報を返している" do
+        root_group =  create(:group)
+        info = root_group.data_custom([], company, nil, nil, nil)
+        expect(info[0][:company][:name]).to eq company.name
+        expect(info[0][:company][:id]).to eq company.id
+      end
+
+      it "親部署が渡されていた時に会社の情報を返している" do
+        root_group =  create(:group, :have_parent)
+        parent_group = root_group.children[0]
+        info = root_group.data_custom([], company, parent_group, nil, nil)
+        expect(info[0][:parent_group][:name]).to eq parent_group.name
+        expect(info[0][:parent_group][:id]).to eq parent_group.id
+      end
+
+      it "子部署が渡されていた時に会社の情報を返している" do
+        root_group = create(:group, :have_child)
+        parent_group = root_group.children[0]
+        child_group =  root_group.children[0].children[0]  
+        info = root_group.data_custom([], company, parent_group, child_group, nil)
+        expect(info[0][:child_group][:name]).to eq child_group.name
+        expect(info[0][:child_group][:id]).to eq child_group.id
+      end
+
+      it "孫部署が渡されていた時に会社の情報を返している" do
+        root_group = create(:group, :have_grand_child)
+        parent_group = root_group.children[0]
+        child_group = root_group.children[0].children[0]
+        grand_child_group =  root_group.children[0].children[0].children[0] 
+        info = root_group.data_custom([], company, parent_group, child_group, grand_child_group)
+        expect(info[0][:grandchild_group][:name]).to eq grand_child_group.name
+        expect(info[0][:grandchild_group][:id]).to eq grand_child_group.id
+      end      
+    end
+
+  end
+end


### PR DESCRIPTION
# 概要
groupモデルに関連する必要最低限のRspecテストを実装

## 実装内容
①以下の4つのテストを実装

- groupテーブルへの保存
  - 名前がある。
  - 名前がない。

- ancestryが正しく機能する
  - 階層ごとにgroupが保存できる
    - rootがcompanyと同じもので登録されている
    - 親部署が登録できる
    - 子部署が登録できる
    - 孫部署が登録できる
- data_customメソッド   
  - 値が正しく返ってくる
    - companyが渡されていた時に会社の情報を返している
    - 親部署が渡されていた時に会社の情報を返している
    - 子部署が渡されていた時に会社の情報を返している
    - 孫部署が渡されていた時に会社の情報を返している


##  実装したソースコード

**spec/models/group_spec.rb**
```
require 'rails_helper'

RSpec.describe Group, type: :model do
  let(:group) { build(:group)}
  describe "#create" do
    context "保存できる"  do
      it "名前がある" do
        group.valid?
        expect(group).to be_valid
      end
    end

    context "保存できない" do
      it "名前が入力されていない" do
        no_name_group = build(:group, name: nil)
        no_name_group.valid?
        expect(no_name_group.errors[:name]).to include("を入力してください")
      end
    end
  end

  describe "ancestryが正しく機能する" do
    context "階層ごとにgroupが保存できる" do
      it "rootがcompanyと同じもので登録されている" do
        root_group = create(:group)
        expect(root_group.depth).to eq 0
      end

      it "親部署が登録できる" do
        root_group = create(:group, :have_parent)
        parent_group =  root_group.children[0]  
        expect(parent_group.depth).to eq 1
      end

      it "子部署部署が登録できる" do
        root_group = create(:group, :have_child)
        child_group =  root_group.children[0].children[0]  
        expect(child_group.depth).to eq 2
      end

      it "孫部署が登録できる" do
        root_group = create(:group, :have_grand_child)
        grand_child_group =  root_group.children[0].children[0].children[0] 
        expect(grand_child_group.depth).to eq 3
      end
    end

  end

  describe "data_customメソッド" do
    context "値が正しく返ってくる" do
      it "companyが渡されていた時に会社の情報を返している" do
        company = create(:company)
        root_group =  create(:group)
        info = root_group.data_custom([], company, nil, nil, nil)
        expect(info[0][:company][:name]).to eq company.name
        expect(info[0][:company][:id]).to eq company.id
      end

      it "親部署が渡されていた時に会社の情報を返している" do
        company = create(:company)
        root_group =  create(:group, :have_parent)
        parent_group = root_group.children[0]
        info = root_group.data_custom([], company, parent_group, nil, nil)
        expect(info[0][:parent_group][:name]).to eq parent_group.name
        expect(info[0][:parent_group][:id]).to eq parent_group.id
      end

      it "子部署が渡されていた時に会社の情報を返している" do
        company = create(:company)
        root_group = create(:group, :have_child)
        parent_group = root_group.children[0]
        child_group =  root_group.children[0].children[0]  
        info = root_group.data_custom([], company, parent_group, child_group, nil)
        expect(info[0][:child_group][:name]).to eq child_group.name
        expect(info[0][:child_group][:id]).to eq child_group.id
      end

      it "孫部署が渡されていた時に会社の情報を返している" do
        company = create(:company)
        root_group = create(:group, :have_grand_child)
        parent_group = root_group.children[0]
        child_group = root_group.children[0].children[0]
        grand_child_group =  root_group.children[0].children[0].children[0] 
        info = root_group.data_custom([], company, parent_group, child_group, grand_child_group)
        expect(info[0][:grandchild_group][:name]).to eq grand_child_group.name
        expect(info[0][:grandchild_group][:id]).to eq grand_child_group.id
      end      
    end

  end
end
```

## 実装結果
**rspec spec/models/group_spec.rbの実行結果**

```
020-07-28 17:11:39 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

Group
  #create
    保存できる
      名前がある
    保存できない
      名前が入力されていない
  ancestryが正しく機能する
    階層ごとにgroupが保存できる
      rootがcompanと同じもので登録されている
      親部署が登録できる
      子部署部署が登録できる
      孫部署が登録できる
  data_customメソッド
    値が正しく返ってくる
      companyが渡されていた時に会社の情報を返している
      親部署が渡されていた時に会社の情報を返している
      子部署が渡されていた時に会社の情報を返している
      孫部署が渡されていた時に会社の情報を返している

Finished in 1.19 seconds (files took 4.51 seconds to load)
10 examples, 0 failures
```

## 相談したいこと
- ancestoryのテストでうまくいかなかった場合のテストを考えつかなかった・・・

## 特に確認して欲しい箇所
- [ ] 他にテストが必要な箇所はないか
- [ ] 不必要なテストを実装していないか
- [ ] 冗長な記述はないか