### PR TITLE
recommit thank_spec

### DIFF
--- a/spec/models/thank_spec.rb
+++ b/spec/models/thank_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Thank, type: :model do
+  describe '#create' do
+    context 'can save' do
+      it 'is valid with text' do
+        receiver = create(:user)
+        sender = create(:user)
+        expect(build(:thank, receiver_id: receiver.id, sender_id: sender.id)).to be_valid
+      end
+    end
+
+    context 'can not save' do
+
+      it 'is invalid without sender' do
+        receiver = create(:user)
+        sender = create(:user)
+        thank = build(:thank, receiver_id: receiver.id, sender_id: nil)
+        thank.valid?
+        expect(thank.errors[:sender]).to include("を入力してください")
+      end
+
+      it 'is invalid without receiver' do
+        receiver = create(:user)
+        sender = create(:user)
+        thank = build(:thank, text: nil, receiver_id: nil, sender_id: sender.id)
+        thank.valid?
+        expect(thank.errors[:receiver]).to include("を入力してください")
+      end
+
+      it 'is invalid without text' do
+        receiver = create(:user)
+        sender = create(:user)
+        thank = build(:thank, text: nil, receiver_id: receiver.id, sender_id: sender.id)
+        thank.valid?
+        expect(thank.errors[:text]).to include("を入力してください")
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
# 概要
thanksテーブルに関連する必要最低限のRspecテストを実装

## 実装内容
①以下の4つのテストを実装

- メッセージが保存できる
  - 送信者、受信者、テキストが全て入力されていること

- メッセージが保存できない
  - 送信者が設定されていない
  - 受信者が設定されていない
  - テキストが入力されていない

②今後必要だと思われるテストの雛形を記述

##  実装したソースコード

**spec/models/thank_spec.rb**
```js
require 'rails_helper'

RSpec.describe Thank, type: :model do
  describe '#create' do

    let(:user) { create(:user) }
    let(:sender) { create(:sender) }
    let(:receiver) { create(:receiver) }

    context '現在実装されている機能' do
      context 'thanksメッセージが保存できる' do
        it 'メッセージテキストが有効' do
          valid_thank = build(:thank) 
          expect(valid_thank).to be_valid
        end
      end

      context 'thanksメッセージが保存できない' do
        
        it '送信者が無効の場合' do
          no_sender_thank = build(:thank, sender_id: nil)
          no_sender_thank.valid?
          expect(no_sender_thank.errors[:sender]).to include("を入力してください")
        end

        it '受信者の設定ができていない' do
          no_reciever_thank = build(:thank, receiver_id: nil)
          no_reciever_thank.valid?
          expect(no_reciever_thank.errors[:receiver]).to include("を入力してください")
        end

        it 'メッセージテキストがない' do
          no_text_thank = build(:thank, text: nil)
          no_text_thank.valid?
          expect(no_text_thank.errors[:text]).to include("を入力してください")
        end
      end
    end

  end
end
```

## 実装結果
**rspec spec/models/thank_spec.rbの実行結果**

```
WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

Thank
  #create
    現在実装されている機能
      thanksメッセージが保存できる
        メッセージテキストが有効
      thanksメッセージが保存できない
        送信者が無効の場合
        受信者の設定ができていない
        メッセージテキストがない

Finished in 0.71338 seconds (files took 5.99 seconds to load)
4 examples, 0 failures
```

## 相談したいこと
- 送信者一覧を機能するJSで自分以外が候補として出てくる仕様になっているかと思うが、送信者リストに乗ってしまっていた時のためにテストが必要か？ (現在送信者と受信者が同一でもtrueになる。)
- 送信者一覧を機能するJSで一度送信した人が候補として出てこない仕様になっているかと思うが、送信者リストに乗ってしまっていた時のためにテストが必要か？ (現在送信済みのユーザー宛てに送るとvalidationの結果がtrueになる。)
- 現在のところ月が切り替わったタイミングリセットされていない。どのような実装方法か相談する必要があり。
   - [ ] ①(JS側)宛先リストを月が変われば全部リセットして読み込む方法
   - [ ] ②(バックエンド側)送信履歴を管理するテーブルを作成する
   - [ ] 個人的な意見としては②のバックエンドで管理した方がテストがしやすい。今後パワープレイをしなくて済むかと思われる。

## 特に確認して欲しい箇所
- [ ] 他にテストが必要な箇所はないか
- [ ] 不必要なテストを実装していないか
- [ ] 冗長な記述はないか