### PR TITLE
新規グループ作成のsystem spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,8 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  # gem 'chromedriver-helper'
+  gem 'webdrivers'
 end
 
 group :production do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include CreateRandomString
-
+  config.include SignIn
   Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
   config.include Devise::Test::ControllerHelpers, type: :controller
   # config.include ControllerMacros, type: :controller

--- a/spec/support/user_sign_in.rb
+++ b/spec/support/user_sign_in.rb
@@ -1,0 +1,17 @@
+module SignIn
+  def sign_in(user)
+    # サインインページへ移動する
+    ActionController::Base.allow_forgery_protection = true
+
+    visit  new_user_session_path
+    # すでに保存されているユーザーのemailとpasswordを入力する
+    fill_in 'email', with: user.email
+    fill_in 'pass', with: user.password
+
+    # ログインボタンをクリックする
+    click_button "ログイン"
+    sleep 3
+
+  end
+
+end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe "Groups", type: :system do
+  let(:user) {create(:user)}
+
+  context '正しくページ遷移できる場合' do
+    it 'グループ新規登録画面へ繊維すること' do
+      sign_in(user)
+
+      click_on('新規登録')
+
+      expect(current_path).to eq new_group_path
+
+    end
+    # TODO:仮置きのherfを修正する
+    # it 'グループ編集画面へ繊維すること' do
+    #   sign_in(user)
+
+    #   click_on('選択')
+
+    #   expect(current_path).to eq edit_user_path(user.id)
+    # end
+  end
+
+  context 'グループの新規登録機能' do
+    it '新しいグループを全て作成すること' do
+      sign_in(user)
+
+      company_name = "株式会社樋口カンパニー"
+      company_parent_name = "コンテンツ"
+      company_child_name = "教材開発"
+      company_grand_child_name = "樋口応用チーム"
+
+      post_number = "123-4567"
+      address = "東京都新宿丸の内ビル"
+      phone_number = "090-1234-5678"
+
+      click_on('新規登録')
+
+      find("input[placeholder='例）株式会社〇〇〇〇']").set(company_name)
+      find("input[placeholder='例）123-xxxx']").set(post_number)
+      find("input[placeholder='例）東京都〇〇区〇〇〇〇']").set(address)
+      find("input[placeholder='例）0120-1234-xxxx']").set(phone_number)
+
+      find("input[type='submit']").click
+
+      expect(page).to have_content('登録が完了しました！')
+      expect(page).to have_content('ユーザー設定画面から部署に参加してください')
+
+      click_on('Close')
+
+      expect(page).to have_selector "section[class='group']"
+      expect(page).to have_selector "option", text: company_name
+      expect(page).to have_selector "input[placeholder='親部署名']"
+
+      find("input[placeholder='親部署名']").set(company_parent_name)
+
+      expect(page).to have_selector "input[placeholder='子部署名']"
+
+      find("input[placeholder='子部署名']").set(company_child_name)
+
+      expect(page).to have_selector "input[placeholder='孫部署名']"
+
+      find("input[placeholder='孫部署名']").set(company_grand_child_name)
+
+      find_all("input[type='submit']")[1].click
+
+      expect(page).to have_content('登録が完了しました！')
+      expect(page).to have_content('ユーザー設定画面から部署に参加してください')
+
+      click_on('Close')
+
+      visit edit_user_path(user.id)
+
+      find_all("select")[0].select(company_name)
+      find_all("select")[1].select(company_parent_name)
+      find_all("select")[2].select(company_child_name)
+      find_all("select")[3].select(company_grand_child_name)
+
+      find("input[value='登録']").click
+
+      expect(page).to have_content('登録が完了しました！')
+      click_on('Close')
+
+      expect(page).to have_content(company_name)
+      expect(page).to have_content(company_parent_name)
+      expect(page).to have_content(company_child_name)
+      expect(page).to have_content(company_grand_child_name)
+    end
+  end
+end


### PR DESCRIPTION
# 概要
system specを用いて、グループ管理機能のテストを実装した
## 実装内容
以下の2つのテストを実装

**ページ遷移が正しくできること**
- グループ新規登録画面へ繊維すること
- グループ編集画面へ繊維すること（NavMypage.vueの編集が必要なため保留）
  
**グループの新規登録機能**
- 新規に会社登録ができること
- 新規に部署登録（親）ができること
- 新規に部署登録（子）ができること
- 新規に部署登録（孫）ができること

##  実装したソースコード

```ruby
require 'rails_helper'

RSpec.describe "Groups", type: :system do
  let(:user) {create(:user)}

  context '正しくページ遷移できる場合' do
    it 'グループ新規登録画面へ繊維すること' do
      sign_in(user)

      click_on('新規登録')

      expect(current_path).to eq new_group_path

    end
    # TODO:仮置きのherfを修正する
    # it 'グループ編集画面へ繊維すること' do
    #   sign_in(user)

    #   click_on('選択')

    #   expect(current_path).to eq edit_user_path(user.id)
    # end
  end

  context 'グループの新規登録機能' do
    it '新しいグループを全て作成すること' do
      sign_in(user)

      company_name = "株式会社樋口カンパニー"
      company_parent_name = "コンテンツ"
      company_child_name = "教材開発"
      company_grand_child_name = "樋口応用チーム"

      post_number = "123-4567"
      address = "東京都新宿丸の内ビル"
      phone_number = "090-1234-5678"

      click_on('新規登録')

      find("input[placeholder='例）株式会社〇〇〇〇']").set(company_name)
      find("input[placeholder='例）123-xxxx']").set(post_number)
      find("input[placeholder='例）東京都〇〇区〇〇〇〇']").set(address)
      find("input[placeholder='例）0120-1234-xxxx']").set(phone_number)

      find("input[type='submit']").click

      expect(page).to have_content('登録が完了しました！')
      expect(page).to have_content('ユーザー設定画面から部署に参加してください')

      click_on('Close')

      expect(page).to have_selector "section[class='group']"
      expect(page).to have_selector "option", text: company_name
      expect(page).to have_selector "input[placeholder='親部署名']"

      find("input[placeholder='親部署名']").set(company_parent_name)

      expect(page).to have_selector "input[placeholder='子部署名']"

      find("input[placeholder='子部署名']").set(company_child_name)

      expect(page).to have_selector "input[placeholder='孫部署名']"

      find("input[placeholder='孫部署名']").set(company_grand_child_name)

      find_all("input[type='submit']")[1].click

      expect(page).to have_content('登録が完了しました！')
      expect(page).to have_content('ユーザー設定画面から部署に参加してください')

      click_on('Close')

      visit edit_user_path(user.id)

      find_all("select")[0].select(company_name)
      find_all("select")[1].select(company_parent_name)
      find_all("select")[2].select(company_child_name)
      find_all("select")[3].select(company_grand_child_name)

      find("input[value='登録']").click

      expect(page).to have_content('登録が完了しました！')
      click_on('Close')

      expect(page).to have_content(company_name)
      expect(page).to have_content(company_parent_name)
      expect(page).to have_content(company_child_name)
      expect(page).to have_content(company_grand_child_name)
    end
  end
end

```

## 実行結果
**ターミナル**

```bash
A-118:ThanksApp tech-camp$ bundle exec rspec spec/system/groups_spec.rb 

Groups
  正しくページ遷移できる場合
    グループ新規登録画面へ繊維すること
  グループの新規登録機能
    新しいグループを作成すること

Finished in 13.24 seconds (files took 2.22 seconds to load)
2 examples, 0 failures


```


**ブラウザ**
[![Image from Gyazo](https://i.gyazo.com/1e20f2ef9123639e5d1cd337384080f4.gif)](https://gyazo.com/1e20f2ef9123639e5d1cd337384080f4)