### PR TITLE
自動公開/公開ボタン実装

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,6 +5,8 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano3/unicorn'
+require 'whenever/capistrano'
+
 
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
 

--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,4 @@ gem 'ancestry'
 gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'
+gem 'whenever', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ancestry (3.0.7)
       activerecord (>= 3.2.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     bcrypt (3.1.13)
     bootsnap (1.4.6)
@@ -87,9 +85,7 @@ GEM
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
+    chronic (0.10.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -142,7 +138,6 @@ GEM
     image_processing (1.10.3)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    io-like (0.3.1)
     ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -299,6 +294,10 @@ GEM
       raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -306,6 +305,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -323,7 +324,6 @@ DEPENDENCIES
   capistrano3-unicorn
   capybara (>= 2.15)
   carrierwave
-  chromedriver-helper
   coffee-rails (~> 4.2)
   devise
   factory_bot_rails
@@ -340,7 +340,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   rails-i18n
-  rspec-rails (~> 3.5)
+  rspec-rails (~> 4.0.0)
   sass-rails (~> 5.0)
   selenium-webdriver
   spring
@@ -349,7 +349,9 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn (= 5.4.1)
+  webdrivers
   webpacker (~> 4.2)
+  whenever
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -17,6 +17,8 @@ class CompaniesController < ApplicationController
 
   def create #会社登録
     @company = Company.new(company_params)
+    last_day = Date.new(Time.now.year, Time.now.month, -1).day.to_s
+    @company.release_time = "#{last_day} 23:50" unless params[:company][:release_time]
     if @company.save
       group = @company.groups.new(name: params[:company][:name], user_ids: [current_user.id])
       group.group_users.first.status = "管理者"
@@ -44,6 +46,8 @@ class CompaniesController < ApplicationController
 
   private
   def company_params
-    params.require(:company).permit(:name, :post_number, :address, :phone_number)
+    time = params[:company][:release_time].split(/[年|月|日|:]/)
+    params[:company][:release_time] = Time.new(time[0], time[1], time[2], time[3], time[4])
+    params.require(:company).permit(:name, :post_number, :address, :phone_number, :release_time)
   end
 end

--- a/app/controllers/letters/receive_controller.rb
+++ b/app/controllers/letters/receive_controller.rb
@@ -6,7 +6,7 @@ class Letters::ReceiveController < ApplicationController
       # 検索したい日付を定義
       search_date = params["receive_year"] + "-" + params["receive_month"] +  "-" + "01"
       # 受信したありレターを作成日ベースで検索
-      received_thanks = current_user.received_thanks.where(created_at: search_date.in_time_zone.all_month)
+      received_thanks = current_user.received_thanks.where(created_at: search_date.in_time_zone.all_month).where(release: true)
       # 受信したデータをVueに渡すために加工
       @received_thanks = []
       received_thanks.each do |received_thank|

--- a/app/controllers/letters/timer_controller.rb
+++ b/app/controllers/letters/timer_controller.rb
@@ -1,0 +1,17 @@
+class Letters::TimerController < ApplicationController
+  def index
+    group = current_user.groups&.first&.root
+    company = group.company
+    thanks = Thank.where(group_id: group.id)
+    thanks.where(transmission_status: true)&.each do |thank|
+      thank.update(release: true)
+    end
+    thanks.where(transmission_status: false)&.destroy_all
+
+    year = Time.now.year.to_s
+    month = Time.now.month.to_i
+    last_day = Date.new(Time.now.year, (Time.now.month + 1), -1).day.to_s
+    company.update(release_time: Time.new(year, (month + 1), last_day, 23, 50, 0, "+09:00" ))
+    redirect_to new_group_path
+  end
+end

--- a/app/controllers/receptions_controller.rb
+++ b/app/controllers/receptions_controller.rb
@@ -1,7 +1,7 @@
 class ReceptionsController < ApplicationController
   def index
     user = User.find(params[:user_id])
-    @received_thanks = user.received_thanks
+    @received_thanks = user.received_thanks.where(release: true)
     @receive_thanks = []
     @senders = []
     @received_thanks.each do |receive_thank|

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -64,7 +64,7 @@ class ThanksController < ApplicationController
   private
 
   def thank_params
-    params.require(:thank).permit(:text, :receiver_id).merge(sender_id: current_user.id)
+    params.require(:thank).permit(:text, :receiver_id).merge(sender_id: current_user.id, group_id: current_user.groups.first.root_id)
   end
 
   def update_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,6 +15,7 @@ class Users::SessionsController < Devise::SessionsController
 
     if resource.valid_password?(params[:password])
       sign_in :user, resource
+      redirect_to letters_timer_path
       # return render nothing: true
     else
       render json: {errors: invalid_login_attempt }

--- a/app/javascript/components/groups/GroupNewContent.vue
+++ b/app/javascript/components/groups/GroupNewContent.vue
@@ -45,8 +45,17 @@
               </label>
               <input type="text" class="company__form__boxies__box__text" v-model="current_company.phone_number" placeholder="例）0120-1234-xxxx">
             </div>
+            <div class="company__form__boxies__box">
+              <label>
+                <p class="company__form__boxies__box form--optional">公開日時</p>
+              </label>
+              <input type="datetime" class="company__form__boxies__box__text" v-model="current_company.release_time" placeholder="例）2020年01月01日23:00">
+            </div>
           </div>
-          <input v-if="current_company.admin" type="submit" value="編集" class="company__form__submit" >
+          <div class="company__form__btn-box">
+            <input v-if="current_company.admin" type="submit" value="編集" class="company__form__submit" >
+            <button v-if="current_company.admin"  type="button" @click="releaseThanks" class="company__form__submit" >メッセージ<br>公開</button>
+          </div>
         </form>
       </section>
     </div>
@@ -78,6 +87,12 @@
                 <p class="form--optional">電話番号</p>
               </label>
               <input type="text" class="company__form__boxies__box__text" v-model="company.phone_number" placeholder="例）0120-1234-xxxx">
+            </div>
+            <div class="company__form__boxies__box">
+              <label>
+                <p class="company__form__boxies__box form--optional">公開日時</p>
+              </label>
+              <input type="datetime" class="company__form__boxies__box__text" v-model="current_company.release_time" placeholder="例）2020年01月01日23:00">
             </div>
           </div>
           <input type="submit" value="登録" class="company__form__submit" >
@@ -136,7 +151,8 @@ export default {
         name: '',
         post_number: '',
         address: '',
-        phone_number: ''
+        phone_number: '',
+        release_time: ''
       },
       current_company: {
         id: '',
@@ -144,6 +160,7 @@ export default {
         post_number: '',
         address: '',
         phone_number: '',
+        release_time: '',
         admin: false
       },
       admin_group: {},
@@ -273,6 +290,28 @@ export default {
             this.errors = error.response.data.errors;
           }
         });
+    },
+    releaseThanks: function(e) {
+      axios
+        .get("/letters/timer.json")
+        .then(response => {
+          this.errors = '';
+          if (response.status === 200){
+            if (response.data && response.data.errors) {
+            this.errors = response.data.errors;
+            } else {
+              this.openModal();
+            }
+
+          } else {
+            let e = response.data;
+          }
+        })
+        .catch(error => {
+          if (error.response.data && error.response.data.errors) {
+            this.errors = error.response.data.errors;
+          }
+        });
     }
   },
 }
@@ -359,7 +398,7 @@ form {
 
 /* 会社登録 */
 .company {
-  height: 300px;
+  height: 330px;
 }
 
 .company__form {
@@ -369,6 +408,11 @@ form {
 
 .company__form__boxies {
   width: 83%;
+}
+
+.company__form__btn-box {
+  display: flex;
+  flex-direction: column;
 }
 
 .company__form__boxies__box {
@@ -417,12 +461,12 @@ form {
 
 .company__form__submit {
   width: 100px;
-  height: 120px;
+  height: 90px;
   background: linear-gradient(157.74deg, #F9516F 11.31%, #FF8F6B 87.66%);
   border: none;
   border-radius: 10px;
   color: #fff;
-  margin-top: 30px;
+  margin-top: 20px;
 }
 
 /* 部署登録 */

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,7 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :thanks
   belongs_to :company
   has_ancestry
 

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -1,6 +1,7 @@
 class Thank < ApplicationRecord
   belongs_to :sender, class_name: 'User'
   belongs_to :receiver, class_name: 'User'
+  belongs_to :group
   has_many :comments
   has_many :thank_likes
 

--- a/app/views/companies/index.json.jbuilder
+++ b/app/views/companies/index.json.jbuilder
@@ -1,9 +1,27 @@
 if @company_admin.present?
-  json.company @company_admin
+  @company_admin_data = {
+    id: @company_admin.id,
+    name: @company_admin.name,
+    post_number: @company_admin.post_number,
+    address: @company_admin.address,
+    phone_number: @company_admin.phone_number,
+    logo: @company_admin.logo,
+    release_time: @company_admin.release_time.strftime("%Y年%m月%d日 %H:%M")
+  }
+  json.company @company_admin_data
   json.admin   true
 end
 
 if @company.present?
-  json.company @company
+  @company_data = {
+    id: @company.id,
+    name: @company.name,
+    post_number: @company.post_number,
+    address: @company.address,
+    phone_number: @company.phone_number,
+    logo: @company.logo,
+    release_time: @company.release_time.strftime("%Y年%m月%d日 %H:%M")
+  }
+  json.company @company_data
   json.admin   false
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module ThanksApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,6 @@
 # config valid for current version and patch releases of Capistrano
 # lock "~> 3.11.2"
+require "whenever/capistrano"
 
 # set :application, "my_app_name"
 # set :repo_url, "git@example.com:me/my_repo.git"
@@ -60,6 +61,10 @@ namespace :deploy do
   before :starting, 'deploy:upload'
   after :finishing, 'deploy:cleanup'
 end
+
+set :whenever_roles, :batch
+set :whenever_environment, :production
+set :whenever_command, "RAILS_ENV=#{whenever_environment} bundle exec whenever  --update-crontab"
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,10 @@ Rails.application.routes.draw do
       end
   end
 
+  namespace :letters do
+    get "timer", to:"timer#index"
+  end
+
   # resources :transmissions, only: [:index]
   #   member do
   #     patch "login_update", to: "user/login#update"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,33 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+set :output, File.join(Whenever.path, "log", "cron.log")
+# ジョブの実行環境の指定
+set :environment, :development, :production
+
+# 1分毎に`HelloWorld`を出力する
+every 1.minutes do
+  begin
+    rake "thanks:timer"
+  rescue => e
+    raise e
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,7 +24,7 @@ set :output, File.join(Whenever.path, "log", "cron.log")
 set :environment, :development, :production
 
 # 1分毎に`HelloWorld`を出力する
-every 1.minutes do
+every 1.hours do
   begin
     rake "thanks:timer"
   rescue => e

--- a/db/migrate/20200807023635_add_column_thanks.rb
+++ b/db/migrate/20200807023635_add_column_thanks.rb
@@ -1,0 +1,6 @@
+class AddColumnThanks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :thanks, :group, null: false, foreign_key: true
+    add_column :thanks, :release, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20200807055852_add_column_company.rb
+++ b/db/migrate/20200807055852_add_column_company.rb
@@ -1,0 +1,5 @@
+class AddColumnCompany < ActiveRecord::Migration[5.2]
+  def change
+    add_column :companies, :release_time, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_034434) do
+ActiveRecord::Schema.define(version: 2020_08_07_055852) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "text", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_034434) do
     t.string "logo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "release_time", null: false
     t.index ["name"], name: "index_companies_on_name"
   end
 
@@ -94,6 +95,9 @@ ActiveRecord::Schema.define(version: 2020_03_17_034434) do
     t.boolean "reception_status", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "group_id", null: false
+    t.boolean "release", default: false, null: false
+    t.index ["group_id"], name: "index_thanks_on_group_id"
     t.index ["receiver_id"], name: "index_thanks_on_receiver_id"
     t.index ["sender_id"], name: "index_thanks_on_sender_id"
   end
@@ -141,6 +145,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_034434) do
   add_foreign_key "recomendations", "users", column: "recomender_id"
   add_foreign_key "thank_likes", "thanks"
   add_foreign_key "thank_likes", "users", column: "sender_id"
+  add_foreign_key "thanks", "groups"
   add_foreign_key "thanks", "users", column: "receiver_id"
   add_foreign_key "thanks", "users", column: "sender_id"
   add_foreign_key "user_likes", "users", column: "receiver_id"

--- a/lib/tasks/thanks.rake
+++ b/lib/tasks/thanks.rake
@@ -1,0 +1,7 @@
+require "./lib/thanks_timer.rb"
+namespace :thanks do
+  task :timer => :environment do
+    thanks_timer = ThanksTimer.new
+    thanks_timer.load
+  end
+end

--- a/lib/thanks_timer.rb
+++ b/lib/thanks_timer.rb
@@ -14,7 +14,11 @@ class ThanksTimer
         year = Time.now.year.to_s
         month = Time.now.month.to_i
         last_day = Date.new(Time.now.year, (Time.now.month + 1), -1).day.to_s
-        company.update(release_time: Time.new(year, (month + 1), last_day, 23, 50, 0, "+09:00" ))
+        if release_time.month.to_i == month
+          company.update(release_time: Time.new(year, (month + 1), last_day, 23, 50, 0, "+09:00" ))
+        else
+          company.update(release_time: Time.new(year, month, last_day, 23, 50, 0, "+09:00" ))
+        end
       end
     end
   end

--- a/lib/thanks_timer.rb
+++ b/lib/thanks_timer.rb
@@ -1,0 +1,22 @@
+class ThanksTimer
+  def load
+    puts "load"
+    Company.all.each do |company|
+      if company.release_time <= Time.now
+        puts "release"
+        group = Group.find_by(company_id: company.id)
+        thanks = Thank.where(group_id: group.id)
+        thanks.where(transmission_status: true)&.each do |thank|
+          thank.update(release: true)
+        end
+        thanks.where(transmission_status: false)&.destroy_all
+    
+        year = Time.now.year.to_s
+        month = Time.now.month.to_i
+        last_day = Date.new(Time.now.year, (Time.now.month + 1), -1).day.to_s
+        company.update(release_time: Time.new(year, (month + 1), last_day, 23, 50, 0, "+09:00" ))
+      end
+    end
+  end
+end
+

--- a/spec/factories/thanks.rb
+++ b/spec/factories/thanks.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     text {Faker::Lorem.sentence}
     sender {create(:user)}
     receiver {create(:user)}
+    group {create(:group)}
   end
 end

--- a/spec/models/thank_spec.rb
+++ b/spec/models/thank_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Thank, type: :model do
         expect(thank.errors[:text]).to include("を入力してください")
       end
 
+      it 'is invalid without group' do
+        receiver = create(:user)
+        sender = create(:user)
+        thank = build(:thank, receiver_id: receiver.id, sender_id: sender.id, group_id: nil)
+        thank.valid?
+        expect(thank.errors[:group]).to include("を入力してください")
+      end
+
     end
   end
 end


### PR DESCRIPTION
#実装内容
・会社毎に月毎にに自動でメッセージを公開する機能（デフォルト：毎月末23時50分に公開）
・グループ登録ページに「メッセージ公開ボタン」を追加

<img width="921" alt="company_new" src="https://user-images.githubusercontent.com/47774981/89673673-bad6aa00-d921-11ea-837d-4f338189048d.png">

#実装技術
【自動公開機能】
１、gem "whenever"をインストール
２、1時間毎にタスクを動かし、会社毎の公開設定時間（companiesテーブルのrelease_timeカラム）と現在の時刻を比較
３、公開設定時間より、現在の時刻が進んでいる場合は確定済みメッセージを公開（thaksテーブルのreleaseカラムをtrue変更）
４、公開設定時間より、現在の時刻が進んでいる場合は編集中メッセージを削除
５、次回公開設定時間を月末に設定

【一括公開ボタン】
１、会社登録ページにメッセージ公開ボタンを押す
２、確定済みメッセージを公開（thaksテーブルのreleaseカラムをtrue変更）
３、編集中メッセージを削除
４、次回公開設定時間を月末に設定

【補足】
・thanksテーブルにgroup_idとreleaseカラムを追加
・companiesテーブルにrelease_timeカラムを追加
